### PR TITLE
Update get user utils

### DIFF
--- a/server/src/__tests__/integration/endpoints/users/getUsers.test.ts
+++ b/server/src/__tests__/integration/endpoints/users/getUsers.test.ts
@@ -81,14 +81,22 @@ describe("GET /users", () => {
     expect(res.body.length).toEqual(2);
   });
 
-  it("should return a 500 if an invalid value is passed as a limit query param", async () => {
+  it("should return a 200 code when successfully returning all users when limit query param exceeds amount of documents in dB", async () => {
     const testUsers = createUsers(6);
-    await UserModel.insertMany(testUsers);
+    const insertedUsers = await UserModel.insertMany(testUsers);
 
+    let userArr = [];
+    for (let userObj of insertedUsers) {
+      let user = convertValueToString(userObj.toObject());
+      userArr.push(user);
+    }
+    
     const res = await request(app)
     .get(`/users`)
-    .query({limit: "c"});
+    .query({limit: 30});
     
-    expect(res.status).toBe(500);
-  })
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(userArr);
+  });
+
 });

--- a/server/src/utils/userUtils.ts
+++ b/server/src/utils/userUtils.ts
@@ -1,6 +1,7 @@
 import mongoose, { ObjectId } from "mongoose";
 import UserModel from "../models/user.model";
-import { ValidationError, NotFoundError, InternalServerError } from "./customErrors";
+import { ValidationError, NotFoundError } from "./customErrors";
+import { DEFAULT_LIMIT } from "../config/constants";
 
 exports.createUser = async (newUser: any) => {
     const user = new UserModel(newUser);
@@ -17,24 +18,10 @@ exports.createUser = async (newUser: any) => {
     }
 };
 
-exports.getUsers = async (limit: number) => {
-    try {
-        if(isNaN(limit)) {
-            throw new Error("Invalid limit query param. Limit must be a number");
-
-        } else {
-            const users = await UserModel.find({}).limit(limit);
-        
-            return users;
-        }
-
-    } catch(err) {
-        if(err instanceof mongoose.Error.ValidationError) {
-            throw(new InternalServerError(`Invalid limit param: ${err}`));
-        }
-
-        throw(err);
-    }
+exports.getUsers = async (limit: number = DEFAULT_LIMIT) => {
+        const users = await UserModel.find({}).limit(limit);
+    
+        return users;
 }
 
 exports.getUserById = async (userId: string) => {


### PR DESCRIPTION
Updated getUsers endpoint to return the DEFAULT_LIMIT const if no limit is specified. Removed 500 error for invalid limit query params. Updated getUsers test for limits that exceed the amount of documents in a collection ---> returns all documents as the default.