### PR TITLE
Bug Fix - Experience create and update routes failing

### DIFF
--- a/src/__tests__/integration/endpoints/experiences/createExperience.test.ts
+++ b/src/__tests__/integration/endpoints/experiences/createExperience.test.ts
@@ -4,6 +4,7 @@ import { createExperiences } from "../../../../utils/testDataGen";
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Express } from "express";
 import { performLogin, banUser } from "../../../../utils/testUtils";
+import BanModel from "../../../../models/ban.model";
 import mongoose from "mongoose";
 import fs from "fs";
 import path from "path";
@@ -80,6 +81,19 @@ describe("POST /experiences", () => {
     expect(res.status).toBe(201);
   });
 
+  it("successfully creates an experience when no person photo is uploaded", async () => {
+    const testExperience = createExperiences(1)[0];
+
+    const res = await request(app)
+      .post("/experiences")
+      .field("experience", JSON.stringify(testExperience))
+      .attach("foodPhoto", testFoodPhotoBuffer, "testFoodPhoto.png")
+      .set("Content-Type", "multipart/form-data")
+      .set("Cookie", sessionCookie);
+
+    expect(res.status).toBe(201);
+  });
+
   it("should return a 400 code if invalid object was submitted", async () => {
     const testExperience = {
       title: "This shouldn't work"
@@ -97,7 +111,12 @@ describe("POST /experiences", () => {
   });
 
   it("should return a 403 code if user is banned", async () => {
-    await banUser({ userId: testUser._id });
+    const userBan = await BanModel.create({
+      userId: testUser._id,
+      reason: "Test ban"
+    });
+    expect(userBan).toBeDefined();
+    expect(userBan?.active).toBe(true);
     const testExperience = createExperiences(1)[0];
 
     const res = await request(app)
@@ -108,6 +127,6 @@ describe("POST /experiences", () => {
       .set("Content-Type", "multipart/form-data")
       .set("Cookie", sessionCookie);
 
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(403);
   });
 });

--- a/src/__tests__/integration/endpoints/experiences/updateExperience.test.ts
+++ b/src/__tests__/integration/endpoints/experiences/updateExperience.test.ts
@@ -151,6 +151,146 @@ describe("PATCH /experiences", () => {
     }
   });
 
+  it("successfully updates the image if no food or person photos are included", async () => {
+    const { sessionCookie, testUser } = await performLogin(app);
+    
+    try {
+      const testExperience = createExperiences(1)[0];
+      const insertedExperience = await new ExperienceModel({
+        ...testExperience,
+        creatorId: testUser._id
+      }).save();
+      const updatedExperience = {
+        ...insertedExperience.toObject(),
+        description: "This description has been updated."
+      };
+
+      const res = await request(app)
+        .patch(`/experiences/${insertedExperience._id}`)
+        .field("experience", JSON.stringify(updatedExperience))
+        .set("Content-Type", "multipart/form-data")
+        .set("Cookie", sessionCookie);
+
+      expect(res.status).toBe(200);
+      
+      const retrievedExperience = await ExperienceModel.findById(insertedExperience._id);
+      expect(retrievedExperience).toBeDefined();
+      const {
+        foodPhotoUrl: retrievedFoodPhotoUrl,
+        personPhotoUrl: retrievedPersonPhotoUrl,
+        ...retrievedRest
+      } = retrievedExperience!.toObject();
+      const {
+        foodPhotoUrl: updatedFoodPhotoUrl,
+        personPhotoUrl: updatedPersonPhotoUrl,
+        ...updatedRest
+      } = updatedExperience;
+      expect(retrievedRest).toEqual(updatedRest);
+      expect(retrievedFoodPhotoUrl).toBe(updatedFoodPhotoUrl);
+      expect(retrievedPersonPhotoUrl).toBe(updatedPersonPhotoUrl);
+    } catch(err) {
+      console.log(`sessionCookie: ${sessionCookie}`);
+      console.log(`testUser: ${JSON.stringify(testUser)}`);
+      throw err;
+    } finally {
+      await performLogout(app, testUser._id);
+    }
+  });
+
+  it("successfully updates the image if only a new food photo is included", async () => {
+    const { sessionCookie, testUser } = await performLogin(app);
+    
+    try {
+      const testExperience = createExperiences(1)[0];
+      const insertedExperience = await new ExperienceModel({
+        ...testExperience,
+        creatorId: testUser._id
+      }).save();
+      const updatedExperience = {
+        ...insertedExperience.toObject(),
+        description: "This description has been updated."
+      };
+
+      const res = await request(app)
+        .patch(`/experiences/${insertedExperience._id}`)
+        .field("experience", JSON.stringify(updatedExperience))
+        .attach("foodPhoto", testFoodPhotoBuffer, "testFoodPhoto.png")
+        .set("Content-Type", "multipart/form-data")
+        .set("Cookie", sessionCookie);
+
+      expect(res.status).toBe(200);
+      
+      const retrievedExperience = await ExperienceModel.findById(insertedExperience._id);
+      expect(retrievedExperience).toBeDefined();
+      const {
+        foodPhotoUrl: retrievedFoodPhotoUrl,
+        personPhotoUrl: retrievedPersonPhotoUrl,
+        ...retrievedRest
+      } = retrievedExperience!.toObject();
+      const {
+        foodPhotoUrl: updatedFoodPhotoUrl,
+        personPhotoUrl: updatedPersonPhotoUrl,
+        ...updatedRest
+      } = updatedExperience;
+      expect(retrievedRest).toEqual(updatedRest);
+      expect(retrievedFoodPhotoUrl).not.toBe(updatedFoodPhotoUrl);
+      expect(retrievedPersonPhotoUrl).toBe(updatedPersonPhotoUrl);
+    } catch(err) {
+      console.log(`sessionCookie: ${sessionCookie}`);
+      console.log(`testUser: ${JSON.stringify(testUser)}`);
+      throw err;
+    } finally {
+      await performLogout(app, testUser._id);
+    }
+  });
+
+  it("successfully updates the image if only a new person photo is included", async () => {
+    const { sessionCookie, testUser } = await performLogin(app);
+    
+    try {
+      const testExperience = createExperiences(1)[0];
+      const insertedExperience = await new ExperienceModel({
+        ...testExperience,
+        creatorId: testUser._id
+      }).save();
+      const updatedExperience = {
+        ...insertedExperience.toObject(),
+        description: "This description has been updated."
+      };
+
+      const res = await request(app)
+        .patch(`/experiences/${insertedExperience._id}`)
+        .field("experience", JSON.stringify(updatedExperience))
+        .attach("personPhoto", testPersonPhotoBuffer, "testPersonPhoto.jpg")
+        .set("Content-Type", "multipart/form-data")
+        .set("Cookie", sessionCookie);
+
+      expect(res.status).toBe(200);
+      
+      const retrievedExperience = await ExperienceModel.findById(insertedExperience._id);
+      expect(retrievedExperience).toBeDefined();
+      const {
+        foodPhotoUrl: retrievedFoodPhotoUrl,
+        personPhotoUrl: retrievedPersonPhotoUrl,
+        ...retrievedRest
+      } = retrievedExperience!.toObject();
+      const {
+        foodPhotoUrl: updatedFoodPhotoUrl,
+        personPhotoUrl: updatedPersonPhotoUrl,
+        ...updatedRest
+      } = updatedExperience;
+      expect(retrievedRest).toEqual(updatedRest);
+      expect(retrievedFoodPhotoUrl).toBe(updatedFoodPhotoUrl);
+      expect(retrievedPersonPhotoUrl).not.toBe(updatedPersonPhotoUrl);
+    } catch(err) {
+      console.log(`sessionCookie: ${sessionCookie}`);
+      console.log(`testUser: ${JSON.stringify(testUser)}`);
+      throw err;
+    } finally {
+      await performLogout(app, testUser._id);
+    }
+  });
+
   it("should allow moderators to update experiences that aren't theirs", async () => {
     const { sessionCookie, testUser } = await performLogin(app);
     await upgradePermissions(app, { testUser, makeModerator: true });

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -1,4 +1,4 @@
-import e, { Request, Response, NextFunction } from "express";
+import { Request, Response, NextFunction } from "express";
 import { Experience } from "@projectTypes/experience";
 import { Document } from "mongoose";
 import { CRUDControllerBase } from "./base/CRUDControllerBase";
@@ -12,24 +12,19 @@ import { IMAGE_MAX_WIDTH } from "../config/constants";
 import ExperienceModel from "../models/experience.model";
 import BanModel from "../models/ban.model";
 import fs from "fs";
+import { User } from "@projectTypes/user";
 
 export class ExperienceController extends CRUDControllerBase<Experience & Document> {
   constructor(model: any) {
     super(model);
-  }
+  };
 
   create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const extendedReq = req as FilesRequest;
       const experience = JSON.parse(req.body.experience);
       const foodPhoto = extendedReq.files['foodPhoto'][0];
-      const personPhoto = extendedReq.files['personPhoto'][0];
-      const userBanned = await this.checkBanStatus(experience.creatorId);
-
-      if (userBanned) {
-        res.status(403).json({ message: "User is banned" });
-        return;
-      }
+      const personPhoto = extendedReq.files['personPhoto']?.[0];
 
       const uploadRequest = this.createUploadRequest();
 
@@ -59,14 +54,14 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
       console.error(err);
       next(this.convertMongoError(err));
     }
-  }
+  };
 
   update = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const extendedReq = req as FilesRequest;
       const experience = JSON.parse(req.body.experience);
-      const foodPhoto = extendedReq.files['foodPhoto'][0];
-      const personPhoto = extendedReq.files['personPhoto'][0];
+      const foodPhoto = extendedReq.files['foodPhoto']?.[0];
+      const personPhoto = extendedReq.files['personPhoto']?.[0];
       let newFoodPhotoUrl: string | undefined;
       let newPersonPhotoUrl: string | undefined;
 
@@ -104,7 +99,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
       console.error(err);
       next(this.convertMongoError(err));
     }
-  }
+  };
 
   delete = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
@@ -126,7 +121,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
       console.error(err);
       next(this.convertMongoError(err));
     }
-  }
+  };
 
   private createUploadRequest = () => {
     const storageService = this.createStorageService();
@@ -139,7 +134,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
       storageService,
       IMAGE_MAX_WIDTH
     );
-  }
+  };
 
   private createStorageService = () => {
     if (
@@ -169,15 +164,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
     ) return new MockImageScaler();
 
     return new SharpImageScaler();
-  }
-
-  private checkBanStatus = async (userId: string): Promise<boolean> => {
-    const ban = await BanModel.findOne({ userId });
-
-    if (ban && ban.active) return true;
-
-    return false;
-  }
+  };
 
   protected injectReadProjectionString = (req: Request): string => {
     const { locationsOnly } = req.query;
@@ -213,7 +200,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
         }
       }
     };
-  }
+  };
 
   protected convertBbox = (bbox: string) => {
     const nums = bbox.split(",").map((coord: string) => Number(coord));
@@ -225,7 +212,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
       lowerLeft: [nums[0], nums[1]],
       upperRight: [nums[2], nums[3]]
     };
-  }
+  };
 }
 
 export default new ExperienceController(ExperienceModel);

--- a/src/routes/experiences.route.ts
+++ b/src/routes/experiences.route.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { isAuthenticated, createAuthorizationMiddleware } from "../middleware/authChecks";
+import { isAuthenticated, createAuthorizationMiddleware, checkBanStatus } from "../middleware/authChecks";
 import multer from "multer";
 import ExperienceController from "../controllers/experiences.controller";
 import ExperienceModel from "../models/experience.model";
@@ -10,7 +10,13 @@ const isAuthorized = createAuthorizationMiddleware(ExperienceModel, (user, docum
   return user._id.equals(document.creatorId) || user.isModerator || user.isAdmin;
 });
 
-router.post("/", isAuthenticated, upload.fields([{ name: "foodPhoto", maxCount: 1 }, { name: "personPhoto", maxCount: 1 }]), ExperienceController.create);
+router.post(
+  "/",
+  isAuthenticated,
+  checkBanStatus,
+  upload.fields([{ name: "foodPhoto", maxCount: 1 }, { name: "personPhoto", maxCount: 1 }]),
+  ExperienceController.create
+);
 router.get("/", ExperienceController.read)
 router.get("/:documentId", ExperienceController.readById);
 router.patch("/:documentId", isAuthorized, upload.fields([{ name: "foodPhoto", maxCount: 1 }, { name: "personPhoto", maxCount: 1 }]), ExperienceController.update);


### PR DESCRIPTION
Fixed bug in experience controller that was preventing experiences from being created or updated when one or both images were missing. Also moved ban check to a middleware function. Updated integration tests to check for correct functionality.