### PR TITLE
Delete Posts Option

### DIFF
--- a/src/__tests__/integration/endpoints/users/deleteUser.test.ts
+++ b/src/__tests__/integration/endpoints/users/deleteUser.test.ts
@@ -139,7 +139,7 @@ describe("DELETE /users/{userId}", () => {
 
       insertedExperiences.forEach(async (experience: any) => {
         const retrievedExperience = await ExperienceModel.findById(experience._id);
-        expect(retrievedExperience).toBeDefined();
+        expect(retrievedExperience).not.toBeNull();
       });
     } catch (err) {
       throw err;
@@ -173,7 +173,7 @@ describe("DELETE /users/{userId}", () => {
 
       insertedExperiences.forEach(async (experience: any) => {
         const retrievedExperience = await ExperienceModel.findById(experience._id);
-        expect(retrievedExperience).toBeDefined();
+        expect(retrievedExperience).not.toBeNull();
       });
     } catch (err) {
       throw err;

--- a/src/controllers/base/CRUDControllerBase.ts
+++ b/src/controllers/base/CRUDControllerBase.ts
@@ -90,9 +90,11 @@ export abstract class CRUDControllerBase<T> {
   delete = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { documentId } = req.params;
+      this.beforeDelete(req, documentId);
       const deleteResult = await this.model.deleteOne({ _id: documentId });
 
       if (deleteResult.deletedCount === 0) throw(new Error("Unable to delete document"));
+      this.afterDelete(req, documentId);
   
       res.status(200).send();
     } catch(err) {
@@ -119,6 +121,13 @@ export abstract class CRUDControllerBase<T> {
   protected processUpdateObject = (req: Request, updateObject: any): any => {
     return updateObject;
   };
+
+  // Overwrite this method to perform an action BEFORE a document is deleted from the DB
+  protected beforeDelete = (req: Request, documentId: string): void => {};
+
+  // Overwrite this method to perform an action AFTER a document is deleted from the DB
+  protected afterDelete = (req: Request, documentId: string): void => {};
+
 
   protected convertMongoError = (err: any): any => {
     if (err instanceof Error.ValidationError) {

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -3,6 +3,7 @@ import { CRUDControllerBase } from "./base/CRUDControllerBase";
 import { Document } from "mongoose";
 import { Request, Response, NextFunction } from "express";
 import UserModel from "../models/user.model";
+import ExperienceModel from "../models/experience.model";
 
 export class UserController extends CRUDControllerBase<User & Document> {
   constructor() {
@@ -48,6 +49,12 @@ export class UserController extends CRUDControllerBase<User & Document> {
     const { displayName } = updateObject;
 
     return { displayName };
+  };
+
+  protected afterDelete = async (req: Request, documentId: string) => {
+    const { deletePosts } = req.query;
+
+    if (deletePosts) await ExperienceModel.deleteMany({creatorId: documentId});
   };
 
   fetchUserData = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -54,7 +54,7 @@ export class UserController extends CRUDControllerBase<User & Document> {
   protected afterDelete = async (req: Request, documentId: string) => {
     const { deletePosts } = req.query;
 
-    if (deletePosts) await ExperienceModel.deleteMany({creatorId: documentId});
+    if (deletePosts && deletePosts === "true") await ExperienceModel.deleteMany({creatorId: documentId});
   };
 
   fetchUserData = async (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
Updated the UserController class to check for the presence of a `deletePosts` query param in `DELETE /users/{userId}` requests. If `deletePosts=true` is passed it deletes the user's experience posts after deleting their account.

Updated the deleteUser integration test suite to check for this updated behavior.

Also added hook methods to CRUDControllerBase class to allow extending classes to perform an action either before or after deleting a document.