### PR TITLE
Reaction Endpoints Update

### DIFF
--- a/src/__tests__/integration/endpoints/reactions/createReaction.test.ts
+++ b/src/__tests__/integration/endpoints/reactions/createReaction.test.ts
@@ -9,7 +9,7 @@ import mongoose from "mongoose";
 
 let mongoServer: MongoMemoryServer;
 let app: Express;
-let mockExperienceId: string;
+let mockExperienceId = createRandomId();
 
 const removeMongooseDocFields: any = (obj: any) => {
   if (typeof obj !== 'object' || obj === null) return obj;
@@ -28,13 +28,11 @@ const removeMongooseDocFields: any = (obj: any) => {
   return newObj;
 };
 
-describe("PUT /reactions", () => {
+describe("PUT /experiences/{experienceId}/reactions", () => {
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     const mongoUri = mongoServer.getUri();
     app = await setupApp(mongoUri);
-
-    mockExperienceId = createRandomId();
   });
 
   afterEach(async() => {

--- a/src/__tests__/integration/endpoints/reactions/deleteReaction.test.ts
+++ b/src/__tests__/integration/endpoints/reactions/deleteReaction.test.ts
@@ -1,16 +1,17 @@
 import request from "supertest";
 import { setupApp } from "../../../../config/app";
-import { createReactions } from "../../../../utils/testDataGen";
+import { createReactions, createRandomId } from "../../../../utils/testDataGen";
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Express } from "express";
 import mongoose from "mongoose";
 import ReactionModel from "../../../../models/reaction.model";
-import { performLogin, performLogout, upgradePermissions } from "../../../../utils/testUtils";
+import { performLogin, performLogout } from "../../../../utils/testUtils";
 
 let mongoServer: MongoMemoryServer;
 let app: Express;
+const mockExperienceId = createRandomId();
 
-describe("DELETE /reactions/{reactionId}", () => {
+describe("DELETE/experiences/{experienceId}/reactions/{reactionId}", () => {
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     const uri = mongoServer.getUri();
@@ -29,7 +30,7 @@ describe("DELETE /reactions/{reactionId}", () => {
     const testReaction = createReactions(1)[0];
     const insertedReaction = await new ReactionModel(testReaction).save();
 
-    const res = await request(app).delete(`/reactions/${insertedReaction._id}`);
+    const res = await request(app).delete(`/experiences/${mockExperienceId}/reactions/${insertedReaction._id}`);
 
     expect(res.status).toBe(401);
   });
@@ -44,7 +45,7 @@ describe("DELETE /reactions/{reactionId}", () => {
       expect(insertedReaction._id).not.toBe(testUser._id);
   
       const res = await request(app)
-        .delete(`/reactions/${insertedReaction._id}`)
+        .delete(`/experiences/${mockExperienceId}/reactions/${insertedReaction._id}`)
         .set("Cookie", sessionCookie);
   
       expect(res.status).toBe(403);
@@ -68,7 +69,7 @@ describe("DELETE /reactions/{reactionId}", () => {
       }).save();
 
       const res = await request(app)
-        .delete(`/reactions/${insertedReaction._id}`)
+        .delete(`/experiences/${mockExperienceId}/reactions/${insertedReaction._id}`)
         .set("Cookie", sessionCookie);
 
       expect(res.status).toBe(200);
@@ -89,7 +90,7 @@ describe("DELETE /reactions/{reactionId}", () => {
 
     try {
       const res = await request(app)
-        .delete(`/reactions/1234`)
+        .delete(`/experiences/${mockExperienceId}/reactions/1234`)
         .set("Cookie", sessionCookie);
 
       expect(res.status).toBe(400);

--- a/src/__tests__/integration/endpoints/reactions/getReactionById.test.ts
+++ b/src/__tests__/integration/endpoints/reactions/getReactionById.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import { setupApp } from "../../../../config/app";
-import { createReactions } from "../../../../utils/testDataGen";
+import { createReactions, createRandomId } from "../../../../utils/testDataGen";
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Express } from "express";
 import mongoose from "mongoose";
@@ -8,8 +8,9 @@ import ReactionModel from "../../../../models/reaction.model";
 
 let mongoServer: MongoMemoryServer;
 let app: Express;
+const mockExperienceId = createRandomId();
 
-describe("GET /reaction/{reactionId}", () => {
+describe("GET /experiences/{experienceId}/reaction/{reactionId}", () => {
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     const uri = mongoServer.getUri();
@@ -33,14 +34,14 @@ describe("GET /reaction/{reactionId}", () => {
     const insertedReaction = await new ReactionModel(testReaction).save();
     console.log(`insertedReaction: ${insertedReaction}`);
 
-    const res = await request(app).get(`/reactions/${insertedReaction._id}`);
+    const res = await request(app).get(`/experiences/${mockExperienceId}/reactions/${insertedReaction._id}`);
 
     expect(res.status).toBe(200);
     expect(res.body._id).toEqual(insertedReaction._id.toString());
   });
 
   it("should return a 404 code if experience with provided id doesn't exist", async () => {
-    const res = await request(app).get("/reactions/653d557c56be3d6d264edda2");
+    const res = await request(app).get(`/experiences/${mockExperienceId}/reactions/653d557c56be3d6d264edda2`);
 
     expect(res.status).toBe(404);
   });

--- a/src/__tests__/integration/endpoints/reactions/getReactions.test.ts
+++ b/src/__tests__/integration/endpoints/reactions/getReactions.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import { setupApp } from "../../../../config/app";
-import { createExperiences, createUsers, createReactions } from "../../../../utils/testDataGen";
+import { createReactions, createRandomId, createRandomIds } from "../../../../utils/testDataGen";
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Express } from "express";
 import mongoose from "mongoose";
@@ -12,8 +12,9 @@ import { faker } from "@faker-js/faker";
 
 let mongoServer: MongoMemoryServer;
 let app: Express;
+const mockExperienceId = createRandomId();
 
-describe("GET /flags", () => {
+describe("GET /experiences/{experienceId}/reactions", () => {
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     const uri = mongoServer.getUri();
@@ -31,15 +32,38 @@ describe("GET /flags", () => {
     }
   });
 
-  it("returns a 200 code and DEFAULT_LIMIT records if there are enough records and no other params are specified", async () => {
-    const testReactions = createReactions(DEFAULT_LIMIT * 2);
+  it("returns a 200 code and all reactions for a given experience if no other params are specified", async () => {
+    const fakeExperienceIds = createRandomIds(50);
+    const testReactions = createReactions(200, [mockExperienceId, ...fakeExperienceIds]);
     await ReactionModel.insertMany(testReactions);
 
 
-    const res = await request(app).get(`/reactions`);
+    const res = await request(app).get(`/experiences/${mockExperienceId}/reactions`);
 
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body.length).toBe(DEFAULT_LIMIT);
+    console.log(`Reactions for mockExperienceId: ${JSON.stringify(res.body)}`);
+    res.body.forEach((reaction: any) => {
+      expect(reaction.experienceId.toString()).toBe(mockExperienceId);
+    });
+  });
+
+  it("returns only reactions by the given user for the given experience when userId query param is passed", async () => {
+    const fakeExperienceIds = createRandomIds(3);
+    const fakeUserIds = createRandomIds(3);
+    const testUser = createRandomId();
+    const testUserReactionsForMockExperience = createReactions(2, [mockExperienceId], [testUser]);
+    const testUserReactionsForOtherExperiences = createReactions(4, fakeExperienceIds, [testUser]);
+    const testReactions = createReactions(25, [mockExperienceId, ...fakeExperienceIds], fakeUserIds);
+    await ReactionModel.insertMany([...testReactions, ...testUserReactionsForMockExperience, ...testUserReactionsForOtherExperiences]);
+
+    const res = await request(app).get(`/experiences/${mockExperienceId}/reactions?userId=${testUser}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    res.body.forEach((reaction: any) => {
+      expect(reaction.experienceId.toString()).toBe(mockExperienceId);
+      expect(reaction.userId.toString()).toBe(testUser);
+    });
   });
 });

--- a/src/__tests__/integration/endpoints/reactions/removeReaction.test.ts
+++ b/src/__tests__/integration/endpoints/reactions/removeReaction.test.ts
@@ -1,0 +1,125 @@
+import request from "supertest";
+import { setupApp } from "../../../../config/app";
+import { createRandomId } from "../../../../utils/testDataGen";
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { Express } from "express";
+import { performLogin, performLogout } from "../../../../utils/testUtils";
+import ReactionModel from "../../../../models/reaction.model";
+import mongoose from "mongoose";
+
+let mongoServer: MongoMemoryServer;
+let app: Express;
+let mockExperienceId = createRandomId();
+
+const removeMongooseDocFields: any = (obj: any) => {
+  if (typeof obj !== 'object' || obj === null) return obj;
+
+  if (Array.isArray(obj)) {
+    return obj.map((item: any) => removeMongooseDocFields(item));
+  }
+
+  const newObj: any = {};
+  for (let key in obj) {
+    if (key !== "__v" && key !== "_id") {
+      newObj[key] = removeMongooseDocFields(obj[key]);
+    }
+  }
+
+  return newObj;
+};
+
+describe("PUT /experiences/{experienceId}/reactions", () => {
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    app = await setupApp(mongoUri);
+  });
+
+  afterEach(async() => {
+    ReactionModel.deleteMany({});
+  });
+  
+  afterAll(async () => {
+    await mongoose.connection.close();
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+  });
+
+  it("should return a 401 code if user is not logged in", async () => {
+    const testReaction = {
+      reaction: "meToo"
+    };
+
+    const res = await request(app)
+      .put(`/experiences/${mockExperienceId}/reactions/remove`)
+      .send(testReaction)
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("should return a 200 code upon success and delete the reaction if it exists", async () => {
+    const { sessionCookie, testUser } = await performLogin(app);
+    
+    try {
+      const testReaction = {
+        reaction: "meToo"
+      };
+      const existingReaction = await ReactionModel.create({
+        userId: testUser._id,
+        experienceId: mockExperienceId,
+        reaction: testReaction.reaction
+      });
+      expect(existingReaction._id).toBeDefined();
+      expect(existingReaction.reaction).toBe(testReaction.reaction);
+  
+      const res = await request(app)
+        .put(`/experiences/${mockExperienceId}/reactions/remove`)
+        .send(testReaction)
+        .set("Content-Type", "application/json")
+        .set("Cookie", sessionCookie);
+  
+      expect(res.status).toBe(200);
+
+      const deletedReaction = await ReactionModel.findOne({
+        userId: testUser._id,
+        experienceId: mockExperienceId,
+        reaction: testReaction.reaction
+      });
+
+      expect(deletedReaction).toBeNull();
+    } catch (err) {
+      throw err;
+    } finally {
+      await performLogout(app, testUser);
+    }
+  });
+
+  it("should return a 200 code even if reaction does not exist", async () => {
+    const { sessionCookie, testUser } = await performLogin(app);
+    
+    try {
+      const nonExistentReaction = {
+        userId: testUser._id,
+        experienceId: mockExperienceId,
+        reaction: "willTry"
+      };
+      const queryResult = await ReactionModel.findOne(nonExistentReaction);
+
+      expect(queryResult).toBeNull();
+
+      const res = await request(app)
+        .put(`/experiences/${mockExperienceId}/reactions/remove`)
+        .send({reaction: nonExistentReaction.reaction})
+        .set("Content-Type", "application/json")
+        .set("Cookie", sessionCookie);
+  
+      expect(res.status).toBe(200);
+    } catch (err) {
+      throw err;
+    } finally {
+      await performLogout(app, testUser);
+    }
+  });
+});

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -59,7 +59,7 @@ export const setupApp = async (mongoUri: string) => {
   userRouter.use("/:userId/bans", banRouter);
   app.use("/users", userRouter);
   app.use("/flags", flagRouter);
-  app.use("/reactions", reactionRouter);
+  experienceRouter.use("/:experienceId/reactions", reactionRouter);
   app.use("/auth", authRouter);
 
   // Error handling middleware

--- a/src/controllers/base/CRUDControllerBase.ts
+++ b/src/controllers/base/CRUDControllerBase.ts
@@ -56,7 +56,7 @@ export abstract class CRUDControllerBase<T> {
       if (createdAfter) query.createdDate = { ...query.createdDate, $gt: new Date(`${createdAfter}`) };
       if (excludedIds) query._id = { $nin: excludedIds };
 
-      const finalQuery = await this.modifyReadQuery(query);
+      const finalQuery = await this.modifyReadQuery(req, query);
       const projectionString = this.injectReadProjectionString(req);
       const docs = await this.model
         .find(finalQuery, projectionString)
@@ -101,7 +101,7 @@ export abstract class CRUDControllerBase<T> {
   };
 
   // Overwrite this method to modify the query before it is sent to the database
-  protected modifyReadQuery = async (query: any): Promise<any> => {
+  protected async modifyReadQuery(req: Request, query: any): Promise<any> {
     return query;
   };
 

--- a/src/controllers/experiences.controller.ts
+++ b/src/controllers/experiences.controller.ts
@@ -154,7 +154,7 @@ export class ExperienceController extends CRUDControllerBase<Experience & Docume
     return results;
   };
 
-  protected modifyReadQuery = async (query: any): Promise<any> => {
+  protected modifyReadQuery = async (req: Request, query: any): Promise<any> => {
     const { bbox, locationsOnly, ...rest } = query;
 
     if (!bbox) return rest;

--- a/src/controllers/reactions.controller.ts
+++ b/src/controllers/reactions.controller.ts
@@ -39,18 +39,6 @@ export class ReactionController extends CRUDControllerBase<Reaction & Document> 
     }
   };
 
-  byUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    try {
-      const { _id: userId } = req.user as User;
-      const { experienceId } = req.params;
-  
-      const results = await this.model.find({ userId, experienceId });
-      res.status(200).send(results);
-    } catch (err) {
-      this.handleError(err, next);
-    }
-  };
-
   protected async modifyReadQuery(req: Request, query: any) {
     const { experienceId } = req.params;
 

--- a/src/controllers/reactions.controller.ts
+++ b/src/controllers/reactions.controller.ts
@@ -1,10 +1,74 @@
 import { CRUDControllerBase } from "./base/CRUDControllerBase";
+import { Request, Response, NextFunction } from "express";
 import { Document } from "mongoose";
 import { Reaction } from "@projectTypes/reaction";
 import ReactionModel from "../models/reaction.model";
+import { User } from "@projectTypes/user";
 
 export class ReactionController extends CRUDControllerBase<Reaction & Document> {
   constructor() {
     super(ReactionModel);
+  };
+
+  create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const reactionDoc = this.getDoc(req);
+
+      const existingReaction = await this.model.findOne(reactionDoc);
+
+      if (existingReaction) {
+        res.status(200).send();
+        return;
+      }
+
+      await this.model.create(reactionDoc);
+      res.status(201).send();
+    } catch (err) {
+      this.handleError(err, next);
+    }
+  };
+
+  remove = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const reactionDoc = this.getDoc(req);
+  
+      await this.model.deleteOne(reactionDoc);
+      res.status(200).send();
+    } catch (err) {
+      this.handleError(err, next);
+    }
+  };
+
+  byUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { _id: userId } = req.user as User;
+      const { experienceId } = req.params;
+  
+      const results = await this.model.find({ userId, experienceId });
+      res.status(200).send(results);
+    } catch (err) {
+      this.handleError(err, next);
+    }
+  };
+
+  protected async modifyReadQuery(req: Request, query: any) {
+    const { experienceId } = req.params;
+
+    return {
+      ...query,
+      experienceId
+    };
+  };
+
+  private getDoc = (req: Request) => {
+    const { _id: userId } = req.user as User;
+    const { experienceId } = req.params;
+    const { reaction } = req.body;
+
+    return {
+      userId,
+      experienceId,
+      reaction
+    };
   };
 };

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -9,7 +9,7 @@ export class UserController extends CRUDControllerBase<User & Document> {
     super(UserModel);
   }
 
-  protected modifyReadQuery = async (query: any): Promise<any> => {
+  protected modifyReadQuery = async (req: Request, query: any): Promise<any> => {
     const {
       createdDate,
       ...rest

--- a/src/routes/reactions.route.ts
+++ b/src/routes/reactions.route.ts
@@ -3,15 +3,17 @@ import { isAuthenticated, createAuthorizationMiddleware } from "../middleware/au
 import { ReactionController } from "../controllers/reactions.controller";
 import ReactionModel from "../models/reaction.model";
 
-const router = Router();
+const router = Router({ mergeParams: true });
 const isAuthorized = createAuthorizationMiddleware(ReactionModel, (user, document) => {
   return user._id.equals(document.userId);
 });
 const reactionController = new ReactionController();
 
-router.post("/", isAuthenticated, reactionController.create);
-router.get("/:documentId", reactionController.readById);
+router.put("/", isAuthenticated, reactionController.create);
+router.put("/remove", isAuthenticated, reactionController.remove);
+router.get("/byUser", isAuthenticated, reactionController.byUser);
 router.get("/", reactionController.read);
+router.get("/:documentId", reactionController.readById);
 router.delete("/:documentId", isAuthorized, reactionController.delete);
 
 export default router;

--- a/src/routes/reactions.route.ts
+++ b/src/routes/reactions.route.ts
@@ -11,7 +11,6 @@ const reactionController = new ReactionController();
 
 router.put("/", isAuthenticated, reactionController.create);
 router.put("/remove", isAuthenticated, reactionController.remove);
-router.get("/byUser", isAuthenticated, reactionController.byUser);
 router.get("/", reactionController.read);
 router.get("/:documentId", reactionController.readById);
 router.delete("/:documentId", isAuthorized, reactionController.delete);

--- a/src/utils/testDataGen.ts
+++ b/src/utils/testDataGen.ts
@@ -5,6 +5,10 @@ import { Experience } from "@projectTypes/experience";
 import { ObjectId } from "mongodb";
 import { GENERIC_FOOD_PHOTO_URL, GENERIC_PERSON_PHOTO_URL } from "../config/constants";
 
+export const createRandomId = () => {
+  return new ObjectId(randomInt(99999)).toString();
+};
+
 export const createUsers = (n: number, areModerators = false, areAdmins = false) => {
   if (n < 1) return [];
 
@@ -12,7 +16,7 @@ export const createUsers = (n: number, areModerators = false, areAdmins = false)
 
   for (let i = 0; i < n; i++) {
     users.push({
-      googleId: new ObjectId(randomInt(99999)).toString(),
+      googleId: createRandomId(),
       displayName: faker.person.fullName(),
       emailAddress: faker.internet.email().toLowerCase(),
       isModerator: areModerators,
@@ -254,7 +258,7 @@ export const createExperiences = (n: number, userIds: string[] = []) => {
       flavourProfile: flavourProfiles[randomInt(flavourProfiles.length)],
       periodOfLifeAssociation: periodOfLifeAssociations[randomInt(periodOfLifeAssociations.length)],
       placesToGetFood: createRandomPlaces(randomInt(3)),
-      creatorId: userIds.length ? userIds[randomInt(userIds.length)] : new ObjectId(randomInt(999999))
+      creatorId: userIds.length ? userIds[randomInt(userIds.length)] : createRandomId()
     } as Experience);
   }
 
@@ -294,8 +298,8 @@ export const createReactions = (n: number, experienceIds: string[] = [], userIds
 
   for (let i = 0; i < n; i++) {
     reactions.push({
-      experienceId: experienceIds.length ? experienceIds[randomInt(experienceIds.length)]: new ObjectId(randomInt(999999)),
-      userId: userIds.length ? userIds[randomInt(userIds.length)] : new ObjectId(randomInt(999999)),
+      experienceId: experienceIds.length ? experienceIds[randomInt(experienceIds.length)]: createRandomId(),
+      userId: userIds.length ? userIds[randomInt(userIds.length)] : createRandomId(),
       createdDate: faker.date.past(),
       reaction: ["meToo", "thanksForSharing", "willTry"][randomInt(3)]
     });

--- a/src/utils/testDataGen.ts
+++ b/src/utils/testDataGen.ts
@@ -9,6 +9,16 @@ export const createRandomId = () => {
   return new ObjectId(randomInt(99999)).toString();
 };
 
+export const createRandomIds = (n: number) => {
+  const ids = [];
+
+  for (let i = 0; i < n; i++) {
+    ids.push(new ObjectId(randomInt(99999)).toString())
+  }
+  
+  return ids;
+};
+
 export const createUsers = (n: number, areModerators = false, areAdmins = false) => {
   if (n < 1) return [];
 


### PR DESCRIPTION
- Updates reactions endpoints to use `/experiences/:experienceId/reactions` path to both semantically group reaction queries with a particular experience and to allow the `experienceId` param to be referenced in reaction endpoint requests.
- Added a `create` function that overrides that of CRUDControllerBase. 
  - It uses the `:experienceId` request param and `req.user` to set the `experienceId` and `userId` fields of the new reaction and only expects an object containing the reaction in the request body. 
  - Before creating a new reaction document, it queries the DB to check if a document matching the `experienceId`, `userId`, and `reaction` exists in the database and returns a `200` code without creating a new record if so. 
  - If no document matching the request exists, creates a new document and returns a `201` status code .
  - Updated the HTTP method for the endpoint to `PUT` to reflect the idempotency of the operation.  
- Implemented a `PUT /experiences/:experienceId/reactions/remove` endpoint to allow deletion of a reaction without needing the reaction's ID.
  - Gets the  `experienceId` and `userId` fields from request context like the create endpoint does (and, thus, requires authentication).
  - Only expects an object containing the reaction like the create endpoint as well.
  - Returns a `200` status code upon success.
- Updated `GET /experiences/:experienceId/reactions` to add `experienceId` from the request param to the database query so it only searches for reactions related to the given experience.
- Updated unit tests to verify new functionality.